### PR TITLE
Accept profile files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: black
         args: ['--line-length', '120']
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turbsim-service"
-version = "0.4.2"
+version = "0.5.0"
 description = "Turbsim as a service."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,8 +15,10 @@ REPOSITORY_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 
 class TestApp(unittest.TestCase):
-    def test_app(self):
-        """Test that the app takes input and produces an output manifest with a dataset containing a single `.bts` file."""
+    def test_with_turbsim_input_file_only(self):
+        """Test that the app works with a TurbSim input file only and produces an output manifest with a dataset
+        containing a single `.bts` file.
+        """
         service_configuration, app_configuration = load_service_and_app_configuration(
             service_configuration_path=os.path.join(REPOSITORY_ROOT, "octue.yaml")
         )
@@ -29,6 +31,40 @@ class TestApp(unittest.TestCase):
         )
 
         input_manifest = Manifest(datasets={"turbsim": f"gs://{os.environ['TEST_BUCKET_NAME']}/turbsim"})
+
+        # Mock running an OpenFAST analysis by creating an empty output file.
+        with patch("octue.utils.processes.run_logged_subprocess", self._create_mock_output_file):
+            analysis = runner.run(input_manifest=input_manifest.serialise())
+
+        self.assertIsNone(analysis.output_values)
+        self.assertIsNotNone(analysis.output_manifest)
+        self.assertTrue(len(analysis.output_manifest.datasets["turbsim"].files), 1)
+
+        output_dataset = Dataset(path=analysis.output_manifest.datasets["turbsim"].path)
+
+        with output_dataset.files.one() as (datafile, f):
+            self.assertEqual(f.read(), "This is a mock TurbSim output file.")
+
+    def test_with_turbsim_input_file_and_profile_file(self):
+        """Test that the TurbSim service works when a profile file is provided alongside the input file."""
+        service_configuration, app_configuration = load_service_and_app_configuration(
+            service_configuration_path=os.path.join(REPOSITORY_ROOT, "octue.yaml")
+        )
+
+        runner = Runner.from_configuration(
+            service_configuration=service_configuration,
+            app_configuration=app_configuration,
+            project_name=os.environ["TEST_PROJECT_NAME"],
+            service_id="octue/turbsim-service:test",
+        )
+
+        input_manifest = Manifest(
+            datasets={
+                "turbsim": f"gs://{os.environ['TEST_BUCKET_NAME']}/turbsim_with_profile"
+            }
+        )
+
+        self.assertEqual(len(input_manifest.datasets["turbsim"].files), 2)
 
         # Mock running an OpenFAST analysis by creating an empty output file.
         with patch("octue.utils.processes.run_logged_subprocess", self._create_mock_output_file):

--- a/turbsim_service/app.py
+++ b/turbsim_service/app.py
@@ -25,8 +25,8 @@ def run(analysis):
     temporary_directory = RegisteredTemporaryDirectory().name
     input_dataset = analysis.input_manifest.datasets["turbsim"]
     input_dataset.download(temporary_directory)
-    input_file = input_dataset.files.one()
 
+    input_file = input_dataset.files.filter(name="TurbSim.inp").one()
     logger.info("Starting turbsim analysis.")
     run_logged_subprocess(command=["turbsim", input_file.local_path], logger=logger)
 

--- a/turbsim_service/app.py
+++ b/turbsim_service/app.py
@@ -24,6 +24,15 @@ def run(analysis):
 
     temporary_directory = RegisteredTemporaryDirectory().name
     input_dataset = analysis.input_manifest.datasets["turbsim"]
+
+    number_of_files = len(input_dataset.files)
+
+    if number_of_files not in {1, 2}:
+        raise ValueError(
+            "The input dataset should only contain either 1 or 2 input files - a 'TurbSim.inp' file and, optionally, "
+            f"a profile or timeseries file; received {number_of_files} files."
+        )
+
     input_dataset.download(temporary_directory)
 
     input_file = input_dataset.files.filter(name="TurbSim.inp").one()

--- a/twine.json
+++ b/twine.json
@@ -1,12 +1,14 @@
 {
     "input_manifest": {
         "datasets": {
-            "turbsim": {"purpose": "A dataset containing a single TurbSim.inp file."}
+            "turbsim": {
+                "purpose": "A dataset containing a 'TurbSim.inp' file and, optionally, a profile file or timeseries file."
+            }
         }
     },
     "output_manifest": {
 		"datasets": {
-            "turbsim": {"purpose": "A dataset containing a single TurbSim.bts (binary timeseries) file."}
+            "turbsim": {"purpose": "A dataset containing a single 'TurbSim.bts' (binary timeseries) file."}
         }
 	}
 }


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#8](https://github.com/octue/turbsim-service/pull/8))

### New features
- Allow multiple files in input dataset

### Enhancements
- Update description in `twine.json`
- Raise error if input dataset has no files or more than 2 files

<!--- END AUTOGENERATED NOTES --->